### PR TITLE
Use www subdomain in arduino.cc URLs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 
 The AudioZero library enables an Arduino SAMD Board (e.g., https://store.arduino.cc/catalogsearch/result/?q=mkr[MKR boards], https://store.arduino.cc/arduino-nano-33-iot[Nano 33 IoT], https://store.arduino.cc/arduino-zero[Zero]) to play back .wav files from a storage device like an SD card to the `DAC0`/`A0` pin.
 For more information about this library please visit us at
-http://arduino.cc/en/Reference/AudioZero
+https://www.arduino.cc/en/Reference/AudioZero
 
 == License ==
 

--- a/examples/SimpleAudioPlayerZero/SimpleAudioPlayerZero.ino
+++ b/examples/SimpleAudioPlayerZero/SimpleAudioPlayerZero.ino
@@ -16,7 +16,7 @@
 
  This example code is in the public domain
 
- http://arduino.cc/en/Tutorial/SimpleAudioPlayerZero
+ https://www.arduino.cc/en/Tutorial/SimpleAudioPlayerZero
 
 */
 

--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=Arduino <info@arduino.cc>
 sentence=Allows playing audio files from an SD card. For Arduino Zero, MKRZero and MKR1000 only.
 paragraph=With this library you can use the Arduino Zero ort MKR1000 DAC output (A0) to play audio files.<br />The audio files must be in the raw .wav format.
 category=Signal Input/Output
-url=http://arduino.cc/en/Reference/Audio
+url=https://www.arduino.cc/en/Reference/Audio
 architectures=samd


### PR DESCRIPTION
www.arduino.cc is Arduino's preferred url.