### PR TITLE
Use authenticated GH API requests in "Compile Examples" CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Compile examples
         uses: arduino/compile-sketches@main
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           fqbn: ${{ matrix.fqbn }}
           libraries: |
             # Install the AudioZero library from the local path


### PR DESCRIPTION
The arduino/compile-sketches GitHub Actions action needs to do a GitHub API request to determine the base branch of a PR for the deltas determination. If a token is not defined via the action's github-token input, it does an unauthenticated API request, which is subject to more strict rate limiting policy. Although its unlikely for the number of API requests to exceed the unauthenticated allowance, use of a token ensures it will never happen. GitHub Actions provides a token for this purpose, so there is no need to set up a custom one.